### PR TITLE
Fix Afordin text background gradient missing tailwind color variant number

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => {
           <p className="text-6xl font-semibold">
             Da tu primera charla de programación y aporta valor a la comunidad
             en el{" "}
-            <span className="inline-block bg-gradient-to-r from-caPrimary to-caSecondary text-transparent bg-clip-text">
+            <span className="inline-block bg-gradient-to-r from-caPrimary-500 to-caSecondary-500 text-transparent bg-clip-text">
               Aforshow
             </span>
           </p>


### PR DESCRIPTION
## Changes Made 🎉

<!-- Add, update or remove from below -->

- [x] fix: add colors number

### Describe Changes

Aforshow page was missing "Afordin" text background gradient, the issue was the tailwind colors were updated to include color variants.

#### Fix

- `from-caPrimary` -> `from-caPrimary-500`.
- `from-caSecondary` -> `from-caSecondary-500`.

## Related Issue(s)

- Issue Number

## Visuals (Optional)

### Before
![missing-afordin-text-gradient](https://github.com/user-attachments/assets/70ca2201-e0be-42bf-89b9-513d8b676dcb)

### After
![fix-afordin-text-gradient](https://github.com/user-attachments/assets/ed0e18d5-01f5-4f56-a595-f5e91d7c7ba6)

<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
