### PR TITLE
fix: config conflicts with packageManeger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 .yarn/install-state.gz
+package-lock.json
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -29,6 +29,5 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
-  },
-  "packageManager": ">=pnpm@8.0.0"
+  }
 }


### PR DESCRIPTION
fix #39

## Changes Made 🎉

When new collaborators try to set up this project, even if they have a higher version of pnpm than the specified in the package.json file with "packageManager": ">=pnpm@8.0.0" they encounter this error.
ERR_PNPM_OTHER_PM_EXPECTED  This project is configured to use >=pnpm

This is because the packageManager only accepts an exact version, we can't configure for a range.

To fix this issue, we can remove this line from package.json. However, we may encounter the same problem in issue https://github.com/Afordin/aforshow-2024/issues/37, and have multiple lock files.

Therefore, I suggest adding these lock files to the .gitignore.

## Related Issue(s)

- Issue Number #39 

## Visuals (Optional)

![image](https://github.com/user-attachments/assets/1a5be58a-e5b2-4a0c-9c4c-397657646464)

## Checklist ✅

- [x] My code follows the code style of this project.
